### PR TITLE
allow configuration

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,4 +5,6 @@ services:
       context: ./
       dockerfile: ./Dockerfile
     restart: unless-stopped
+    volumes:
+      - config.json:/usr/src/bot/config.json
     env_file: ./.env

--- a/config.json
+++ b/config.json
@@ -1,0 +1,7 @@
+{
+    "numberRepostReaction": "1",
+    "channelSondage": "1038906584673304683",
+    "channelMeme": "1214916882268946433",
+    "roleMod": "1214514570643906600",
+    "logWarnMod": "1038906584673304683"
+}

--- a/config.json
+++ b/config.json
@@ -1,7 +1,2 @@
 {
-    "numberRepostReaction": "1",
-    "channelSondage": "1038906584673304683",
-    "channelMeme": "1214916882268946433",
-    "roleMod": "1214514570643906600",
-    "logWarnMod": "1038906584673304683"
 }

--- a/deploy-docker.sh
+++ b/deploy-docker.sh
@@ -2,5 +2,5 @@ echo "Deploiement alterbot"
 cd /mnt/tank/configs/alterbot/AlterBot
 docker compose down alterbot
 git pull origin main
-docker compose up -d --no-deps --build alterbot
+docker compose up -d alterbot
 echo "Deploiement termine"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "commonjs",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/slash/utility/configure.js
+++ b/slash/utility/configure.js
@@ -1,0 +1,61 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const utilities = require("../../utilities")
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('configure')
+        .setDescription('Configure the bot settings')
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+        .addStringOption(option =>
+            option.setName('setting')
+                .setDescription('The setting to configure')
+                .setRequired(true)
+                .setAutocomplete(true))
+        .addStringOption(option =>
+            option.setName('value')
+                .setDescription('The value to set for the setting')
+                .setRequired(true)
+                .setAutocomplete(true)),
+
+    async autocomplete(interaction) {
+        const focusedOption = interaction.options.getFocused(true);
+        if (focusedOption.name === 'setting') {
+            const settings = utilities.allowedConfigProperties;
+            const filtered = settings.filter(setting => setting.startsWith(focusedOption.value));
+            await interaction.respond(filtered.map(setting => ({ name: setting, value: setting })));
+        } else if (focusedOption.name === 'value') {
+            const setting = interaction.options.getString("setting");
+            if (!utilities.allowedConfigProperties.includes(setting)) {
+                await interaction.respond({name: "Invalid setting", value: "Invalid setting"});
+                return;
+            }
+            if (setting.startsWith("channel")){
+                const channels = interaction.guild.channels.cache.filter(channel => channel.name.startsWith(focusedOption.value));
+                await interaction.respond(channels.map(channel => ({ name: channel.name, value: channel.id })));
+            } else if (setting.startsWith("role")) {
+                const roles = interaction.guild.roles.cache.filter(role => role.name.startsWith(focusedOption.value));
+                await interaction.respond(roles.map(role => ({ name: role.name, value: role.id })));
+            } else if (focusedOption.value !== '') {
+                await interaction.respond([{ name: focusedOption.value, value: focusedOption.value }]);
+            }
+        }
+    },
+    async execute(interaction) {
+        const setting = interaction.options.getString('setting');
+        const value = interaction.options.getString('value');
+        if (!utilities.allowedConfigProperties.includes(setting)) {
+            await interaction.reply({content: "Invalid setting", ephemeral: true});
+            return;
+        } else {
+            utilities.config[setting] = value;
+            await utilities.syncConfig()
+        }
+        if (setting.startsWith("channel")) {
+            await interaction.reply(`Setting ${setting} has been set to <#${value}>.`);
+        } else if (setting.startsWith("role")) {
+            await interaction.reply(`Setting ${setting} has been set to <@&${value}>.`);
+        } else {
+            await interaction.reply(`Setting ${setting} has been set to ${value}.`);
+        }
+    }
+}

--- a/slash/utility/ping.js
+++ b/slash/utility/ping.js
@@ -1,11 +1,11 @@
-const { SlashCommandBuilder } = require('@discordjs/builders');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
 	data: new SlashCommandBuilder()
 		.setName('ping')
-		.setDescription('Replies with Pong!')
-		.setDefaultPermission(true),
-    /**
+		.setDescription('Replies with Pong!'),
+
+	/**
      * @param {Discord.CommandInteraction} interaction 
      */
 	async execute(interaction) {


### PR DESCRIPTION
Permet aux personnes avec la permission de Gérer le Serveur de modifier certains paramètres du bot tel que les salons désignés (memes et sondage), le rôle de modération (quoiqu'il a l'air inutilisé), ou le nombre de réaction pour qu'un message soit flag comme repost.

J'ai monté le fichier config.json comme volume pour qu'il soit persistant, si ca ne te convient pas change le.